### PR TITLE
feat: .eslintrc.jsとImportMetaEnvを追加

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { resolve, join } from "node:path";
 import { mkdirSync, writeFileSync } from "node:fs";
 

--- a/template/base/_eslintrc.js
+++ b/template/base/_eslintrc.js
@@ -1,0 +1,21 @@
+module.exports = {
+  env: {
+    node: true,
+    browser: true,
+    es2022: true,
+  },
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  plugins: ["vue", "@typescript-eslint/eslint-plugin"],
+  extends: [
+    "plugin:@typescript-eslint/recommended",
+    "plugin:vue/vue3-essential",
+    "@vue/typescript/recommended",
+  ],
+  ignorePatterns: [".eslintrc.js"],
+  rules: {
+    "vue/multi-word-component-names": "off",
+  },
+};

--- a/template/base/src/vite-env.d.ts
+++ b/template/base/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
- fix: src/index.tsにshebang `#!/usr/bin/env node` を追記
- feat: templateに.eslintrc.jsを追加
- feat: base templateの `vite-env.d.ts` に `interface ImportMetaEnv` と `interface ImportMeta` を追加